### PR TITLE
Fix Lexer trace output to present full lexeme

### DIFF
--- a/src/main/resources/templates/java/LexerCode.java.ftl
+++ b/src/main/resources/templates/java/LexerCode.java.ftl
@@ -227,7 +227,7 @@
         input_stream.backup(curPos - jjmatchedPos - 1);
       }
        if (trace_enabled) LOGGER.info("****** FOUND A " + tokenImage[jjmatchedKind] + " MATCH ("
-          + ParseException.addEscapes(input_stream.getSuffix(jjmatchedPos + 1)) + ") ******\n");
+          + ParseException.addEscapes(input_stream.getSuffix(jjmatchedPos + 2)) + ") ******\n");
  
  [#if lexerData.hasSkip || lexerData.hasMore || lexerData.hasSpecial]
           if (tokenSet.get(jjmatchedKind)) {


### PR DESCRIPTION
When printing out the lexeme the 1st letter was cut of, because of a false index in the print statement.

So: 

`INFORMATION: ****** FOUND A <DataType> MATCH (nt) ******`

is now:

`INFORMATION: ****** FOUND A <DataType> MATCH (int) ******`