### PR TITLE
Double package declaration in Visitor-Interface

### DIFF
--- a/src/main/resources/templates/java/Visitor.java.ftl
+++ b/src/main/resources/templates/java/Visitor.java.ftl
@@ -33,7 +33,7 @@
 [#if grammar.parserPackage?has_content]
 package ${grammar.parserPackage};
 [/#if]
-[#if explicitPackageName??]
+[#elseif explicitPackageName??]
 package ${explicitPackageName};
 [#elseif grammar.nodePackage?has_content]
 package ${grammar.nodePackage};


### PR DESCRIPTION
The generated Visitor-Interface from Visitor.java.ftl has a doubled package declaration when used with the  PARSER_PACKAGE option in the .jjt-file.
I assume it's caused by the missing "elseif" which is for example present in the template for BaseNode, but this would need to be tested, because I know too less about the internas atm.