### PR TITLE
Change Python lexer specification to detect identifiers with invalid characters

### DIFF
--- a/examples/python/PythonLexer.javacc
+++ b/examples/python/PythonLexer.javacc
@@ -356,3 +356,22 @@ INCLUDE PYTHON_IDENTIFIER_DEF
 TOKEN :
   <NAME : <PYTHON_IDENTIFIER_START> (<PYTHON_IDENTIFIER_PART>)* > #Name
 ;
+
+TOKEN :
+  <BADNAME :
+    [
+       "a"-"z",
+       "A"-"Z",
+       "_",
+       "\u0080"-"\uffff"
+    ]
+    (
+        [
+           "a"-"z",
+           "A"-"Z",
+           "0"-"9",
+           "_",
+           "\u0080"-"\uffff"
+        ]
+    )* >
+;


### PR DESCRIPTION
Added a `BADNAME` token to help identify cases where invalid characters are used in identifiers - it will allow better error messages.