### PR TITLE
Fix #178: Simplify duplicate code in CodeInjector and avoid duplicate object types being added to 'extends' and 'implements' lists.

### DIFF
--- a/src/java/com/javacc/output/csharp/CSharpTranslator.java
+++ b/src/java/com/javacc/output/csharp/CSharpTranslator.java
@@ -34,9 +34,6 @@ import java.util.*;
 import com.javacc.Grammar;
 import com.javacc.output.Translator;
 import com.javacc.output.java.CodeInjector;
-import com.javacc.parser.JavaCCParser;
-import com.javacc.parser.Node;
-import com.javacc.parser.ParseException;
 import com.javacc.parser.tree.*;
 
 public class CSharpTranslator extends Translator {
@@ -499,23 +496,20 @@ public class CSharpTranslator extends Translator {
             addNewline = true;
         }
         else if (stmt instanceof ASTStatementList) {
-            boolean isinitializer = ((ASTStatementList) stmt).isInitializer();
+            boolean isInitializer = ((ASTStatementList) stmt).isInitializer();
             List<ASTStatement> statements = ((ASTStatementList) stmt).getStatements();
 
-            if (isinitializer) {
+            if (isInitializer) {
                 addIndent(indent, result);
                 result.append("{\n");
                 indent += 4;
             }
-            if (statements == null) {
-
-            }
-            else {
+            if (statements != null) {
                 for (ASTStatement s : statements) {
                     internalTranslateStatement(s, indent, result);
                 }
             }
-            if (isinitializer) {
+            if (isInitializer) {
                 indent -= 4;
                 addIndent(indent, result);
                 result.append("}\n");
@@ -936,7 +930,7 @@ public class CSharpTranslator extends Translator {
 
     @Override protected void translateCast(ASTTypeExpression cast, StringBuilder result) {
         result.append('(');
-        translateType(cast, result);;
+        translateType(cast, result);
         result.append(") ");
     }
 

--- a/src/java/com/javacc/output/java/CodeInjector.java
+++ b/src/java/com/javacc/output/java/CodeInjector.java
@@ -42,18 +42,18 @@ import com.javacc.parser.tree.*;
 public class CodeInjector {
     
     private final String parserPackage, nodePackage, parserClassName, lexerClassName, constantsClassName, baseNodeClassName;
-    
-    private final Map<String, TypeDeclaration> types = new HashMap<>();
+
+    private final Map<String, TypeDeclaration> types = new HashMap<>();  // Not presently queried ...
     private final Map<String, Set<ImportDeclaration>> injectedImportsMap = new HashMap<>();
     private final Map<String, Set<Annotation>> injectedAnnotationsMap = new HashMap<>();
     private final Map<String, List<ObjectType>> extendsLists = new HashMap<>();
     private final Map<String, List<ObjectType>> implementsLists = new HashMap<>();
     private final Map<String, TypeParameters> typeParameterLists = new HashMap<>();
     private final Map<String, List<ClassOrInterfaceBodyDeclaration>> bodyDeclarations = new HashMap<>();
-    private final Set<String> overriddenMethods = new HashSet<>();
+    private final Set<String> overriddenMethods = new HashSet<>();  // Not presently queried ...
     private final Set<String> typeNames = new HashSet<>();
     private final Map<String, String> explicitPackages = new HashMap<>();
-    private final Set<String> interfaces = new HashSet<>();
+    private final Set<String> interfaces = new HashSet<>();  // Not presently queried ...
     private final Grammar grammar;
     
     public CodeInjector(Grammar grammar,
@@ -180,7 +180,7 @@ public class CodeInjector {
             }
         }
     }
-    
+
     private void addToDependencies(String name, List<ObjectType> listToAdd, Map<String, List<ObjectType>> mapOfExistingLists) {
         List<ObjectType> existingList = mapOfExistingLists.get(name);
         if (existingList == null) {
@@ -225,7 +225,6 @@ public class CodeInjector {
         if (body != null) {
         	existingDecls.addAll(body.childrenOfType(ClassOrInterfaceBodyDeclaration.class));
         }
-        
     }
 
     void injectCode(CompilationUnit jcu) {


### PR DESCRIPTION
This could happen if e.g. "INJECT Foo: implements Bar" lines are repeated in the grammar file.