### PR TITLE
Fix incorrect previous() method in stackIteratorBackwards

### DIFF
--- a/src/ftl/csharp/Utils.cs.ftl
+++ b/src/ftl/csharp/Utils.cs.ftl
@@ -825,13 +825,13 @@ namespace ${csPackage} {
             _iter2 = new ListIterator<T>(list2, list2.Count);
         }
 
-        public bool HasNext()  => _iter1.HasPrevious() || _iter2.HasPrevious();
+        public bool HasNext()  => _iter2.HasPrevious() || _iter1.HasPrevious();
 
         public T Next() => _iter2.HasPrevious() ? _iter2.Previous() : _iter1.Previous();
 
-        public bool HasPrevious() => _iter2.HasNext() || _iter1.HasNext();
+        public bool HasPrevious() => _iter1.HasNext() || _iter2.HasNext();
 
-        public T Previous() => _iter2.HasNext()  ? _iter2.Next() : _iter1.Next();
+        public T Previous() => _iter1.HasNext()  ? _iter1.Next() : _iter2.Next();
     }
 
     public class GenWrapper<T> : Iterator<T> {

--- a/src/ftl/java/ErrorHandling.java.ftl
+++ b/src/ftl/java/ErrorHandling.java.ftl
@@ -122,16 +122,16 @@ private ListIterator<NonTerminalCall> stackIteratorBackward() {
     final ListIterator<NonTerminalCall> lookaheadStackIterator = lookaheadStack.listIterator(lookaheadStack.size());
     return new ListIterator<NonTerminalCall>() {
         public boolean hasNext() {
-            return parseStackIterator.hasPrevious() || lookaheadStackIterator.hasPrevious();
+            return lookaheadStackIterator.hasPrevious() || parseStackIterator.hasPrevious();
         }
         public NonTerminalCall next() {
             return lookaheadStackIterator.hasPrevious() ? lookaheadStackIterator.previous() : parseStackIterator.previous();
         }
         public NonTerminalCall previous() {
-           return lookaheadStackIterator.hasNext() ? lookaheadStackIterator.next() : parseStackIterator.next();
+           return parseStackIterator.hasNext() ? parseStackIterator.next() : lookaheadStackIterator.next();
         }
         public boolean hasPrevious() {
-            return lookaheadStackIterator.hasNext() || parseStackIterator.hasNext();
+            return parseStackIterator.hasNext() || lookaheadStackIterator.hasNext();
         }
         public void add(NonTerminalCall ntc) {throw new UnsupportedOperationException();}
         public void set(NonTerminalCall ntc) {throw new UnsupportedOperationException();}

--- a/src/ftl/python/error_handling.inc.ftl
+++ b/src/ftl/python/error_handling.inc.ftl
@@ -66,7 +66,7 @@
 
             @property
             def has_next(self):
-                return self.iter1.has_previous or self.iter2.has_previous
+                return self.iter2.has_previous or self.iter1.has_previous
 
             @property
             def next(self):
@@ -74,11 +74,11 @@
 
             @property
             def has_previous(self):
-                return self.iter2.has_next or self.iter1.has_next
+                return self.iter1.has_next or self.iter2.has_next
 
             @property
             def previous(self):
-                return self.iter2.next if self.iter2.has_next else self.iter1.next
+                return self.iter1.next if self.iter1.has_next else self.iter2.next
 
         return BackwardIterator(self.parsing_stack, self.lookahead_stack)
 


### PR DESCRIPTION
Also reorder has...() conditions in both forward and backward templates (cosmetic).  Java has been tested, but Python and CSharp have not.  When I get back to the office I will come up with a test case that could be used, if this is still pending.