### PR TITLE
Add check code style

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,9 @@
 <project name="javacc21" default="compile" basedir=".">
-    <tstamp>
+
+	<taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties"
+	    classpath="lib/checkstyle-10.6.0-all.jar"/>
+
+	<tstamp>
         <format property="timestamp" pattern="yyyy-MM-dd HH:mm:ss" />
     </tstamp>
 
@@ -224,4 +228,14 @@
       <arg line="-u csharp_tests.py"/>
     </exec>
   </target>
+
+    <target name="checkstyle" depends="compile">
+        <checkstyle config="lib/checkstyle-checker.xml" failOnViolation="false">
+            <fileset dir="." includes="**/*.java"/>
+            <formatter type="xml" toFile="build/checkstyle_errors.xml"/>
+            <formatter type="sarif" toFile="build/checkstyle_errors.sarif"/>
+        </checkstyle>
+        <xslt in="build/checkstyle_errors.xml" out="report/checkstyle_report.html"
+              style="lib/checkstyle-noframes-severity-sorted.xsl"/>
+    </target>
 </project>

--- a/lib/checkstyle-checker.xml
+++ b/lib/checkstyle-checker.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      https://docs.oracle.com/javase/specs/jls/se11/html/index.html
+
+    - the Sun Code Conventions at https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
+
+    - the Javadoc guidelines at
+      https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html
+
+    - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
+
+  Finally, it is worth reading the documentation.
+
+-->
+
+<module name="Checker">
+  <!--
+      If you set the basedir property below, then all reported file
+      names will be relative to the specified directory. See
+      https://checkstyle.org/config.html#Checker
+
+      <property name="basedir" value="${basedir}"/>
+  -->
+  <property name="severity" value="error"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/config_filefilters.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+              default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- Checks that a package-info.java file exists for each package.     -->
+  <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+  <module name="JavadocPackage"/>
+
+  <!-- Checks whether files end with a new line.                        -->
+  <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+  <module name="NewlineAtEndOfFile"/>
+
+  <!-- Checks that property files contain the same keys.         -->
+  <!-- See https://checkstyle.org/config_misc.html#Translation -->
+  <module name="Translation"/>
+
+  <!-- Checks for Size Violations.                    -->
+  <!-- See https://checkstyle.org/config_sizes.html -->
+  <module name="FileLength"/>
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See https://checkstyle.org/config_whitespace.html -->
+  <module name="FileTabCharacter"/>
+
+  <!-- Miscellaneous other checks.                   -->
+  <!-- See https://checkstyle.org/config_misc.html -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$"/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Line has trailing spaces."/>
+  </module>
+
+  <!-- Checks for Headers                                -->
+  <!-- See https://checkstyle.org/config_header.html   -->
+  <!-- <module name="Header"> -->
+  <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+  <!--   <property name="fileExtensions" value="java"/> -->
+  <!-- </module> -->
+
+  <module name="TreeWalker">
+
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See https://checkstyle.org/config_javadoc.html -->
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocMethod"/>
+    <module name="JavadocType"/>
+    <module name="JavadocVariable"/>
+    <module name="JavadocStyle"/>
+    <module name="MissingJavadocMethod"/>
+
+    <!-- Checks for Naming Conventions.                  -->
+    <!-- See https://checkstyle.org/config_naming.html -->
+    <module name="ConstantName"/>
+    <module name="LocalFinalVariableName"/>
+    <module name="LocalVariableName"/>
+    <module name="MemberName"/>
+    <module name="MethodName"/>
+    <module name="PackageName"/>
+    <module name="ParameterName"/>
+    <module name="StaticVariableName"/>
+    <module name="TypeName"/>
+
+    <!-- Checks for imports                              -->
+    <!-- See https://checkstyle.org/config_imports.html -->
+    <module name="AvoidStarImport"/>
+    <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+    <module name="RedundantImport"/>
+    <module name="UnusedImports">
+      <property name="processJavadoc" value="false"/>
+    </module>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+    <module name="MethodLength"/>
+    <module name="ParameterNumber"/>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+    <module name="EmptyForIteratorPad"/>
+    <module name="GenericWhitespace"/>
+    <module name="MethodParamPad"/>
+    <module name="NoWhitespaceAfter"/>
+    <module name="NoWhitespaceBefore"/>
+    <module name="OperatorWrap"/>
+    <module name="ParenPad"/>
+    <module name="TypecastParenPad"/>
+    <module name="WhitespaceAfter"/>
+    <module name="WhitespaceAround"/>
+
+    <!-- Modifier Checks                                    -->
+    <!-- See https://checkstyle.org/config_modifier.html -->
+    <module name="ModifierOrder"/>
+    <module name="RedundantModifier"/>
+
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See https://checkstyle.org/config_blocks.html -->
+    <module name="AvoidNestedBlocks"/>
+    <module name="EmptyBlock"/>
+    <module name="LeftCurly"/>
+    <module name="NeedBraces"/>
+    <module name="RightCurly"/>
+
+    <!-- Checks for common coding problems               -->
+    <!-- See https://checkstyle.org/config_coding.html -->
+    <module name="EmptyStatement"/>
+    <module name="EqualsHashCode"/>
+    <module name="HiddenField"/>
+    <module name="IllegalInstantiation"/>
+    <module name="InnerAssignment"/>
+    <module name="MagicNumber"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="SimplifyBooleanExpression"/>
+    <module name="SimplifyBooleanReturn"/>
+
+    <!-- Checks for class design                         -->
+    <!-- See https://checkstyle.org/config_design.html -->
+    <module name="DesignForExtension"/>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
+    <module name="InterfaceIsType"/>
+    <module name="VisibilityModifier"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+    <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters"/>
+    <module name="TodoComment"/>
+    <module name="UpperEll"/>
+
+    <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+
+  </module>
+
+</module>

--- a/lib/checkstyle-noframes-severity-sorted.xsl
+++ b/lib/checkstyle-noframes-severity-sorted.xsl
@@ -1,0 +1,210 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:output method="html" indent="yes"/>
+<xsl:decimal-format decimal-separator="." grouping-separator="," />
+
+<xsl:key name="files" match="file" use="@name" />
+
+<!-- Checkstyle XML Style Sheet by Rolf Wojtech <rolf@wojtech.de>                   -->
+<!-- (based on checkstyle-noframe-sorted.xsl by Stephane Bailliez                   -->
+<!--  <sbailliez@apache.org> and sf-patch 1721291 by Leo Liang)                     -->
+<!-- Changes: 																								                      -->
+<!--  * Outputs seperate columns for error/warning/info                             -->
+<!--  * Sorts primarily by #error, secondarily by #warning, tertiary by #info       -->
+<!--  * Compatible with windows path names (converts '\' to '/' for html anchor)    -->
+<!--                                                                                -->
+<!-- Part of the Checkstyle distribution found at https://checkstyle.org -->
+<!-- Usage (generates checkstyle_report.html):                                      -->
+<!--    <checkstyle failonviolation="false" config="${check.config}">               -->
+<!--      <fileset dir="${src.dir}" includes="**/*.java"/>                          -->
+<!--      <formatter type="xml" toFile="${doc.dir}/checkstyle_report.xml"/>         -->
+<!--    </checkstyle>                                                               -->
+<!--    <style basedir="${doc.dir}" destdir="${doc.dir}"                            -->
+<!--            includes="checkstyle_report.xml"                                    -->
+<!--            style="${doc.dir}/checkstyle-noframes-severity-sorted.xsl"/>        -->
+
+<xsl:template match="checkstyle">
+  <html>
+    <head>
+    <style type="text/css">
+    .bannercell {
+      border: 0px;
+      padding: 0px;
+    }
+    body {
+      margin-left: 10;
+      margin-right: 10;
+      font:normal 80% arial,helvetica,sanserif;
+      background-color:#FFFFFF;
+      color:#000000;
+    }
+    .a td {
+      background: #efefef;
+    }
+    .b td {
+      background: #fff;
+    }
+    th, td {
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      font-weight:bold;
+      background: #ccc;
+      color: black;
+    }
+    table, th, td {
+      font-size:100%;
+      border: none
+    }
+    table.log tr td, tr th {
+
+    }
+    h2 {
+      font-weight:bold;
+      font-size:140%;
+      margin-bottom: 5;
+    }
+    h3 {
+      font-size:100%;
+      font-weight:bold;
+      background: #525D76;
+      color: white;
+      text-decoration: none;
+      padding: 5px;
+      margin-right: 2px;
+      margin-left: 2px;
+      margin-bottom: 0;
+    }
+    </style>
+    </head>
+    <body>
+      <a name="top"></a>
+      <!-- jakarta logo -->
+      <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td class="bannercell" rowspan="2">
+          <!--a href="http://jakarta.apache.org/">
+          <img src="http://jakarta.apache.org/images/jakarta-logo.gif" alt="http://jakarta.apache.org" align="left" border="0"/>
+          </a-->
+        </td>
+        <td class="text-align:right"><h2>CheckStyle Audit</h2></td>
+        </tr>
+        <tr>
+        <td class="text-align:right">Designed for use with <a href='https://checkstyle.org/'>CheckStyle</a> and <a href='http://jakarta.apache.org'>Ant</a>.</td>
+        </tr>
+      </table>
+      <hr size="1"/>
+
+      <!-- Summary part -->
+      <xsl:apply-templates select="." mode="summary"/>
+      <hr size="1" width="100%" align="left"/>
+
+      <!-- Package List part -->
+      <xsl:apply-templates select="." mode="filelist"/>
+      <hr size="1" width="100%" align="left"/>
+
+      <!-- For each package create its part -->
+            <xsl:apply-templates select="file[@name and generate-id(.) = generate-id(key('files', @name))]" />
+
+      <hr size="1" width="100%" align="left"/>
+
+
+    </body>
+  </html>
+</xsl:template>
+
+
+
+  <xsl:template match="checkstyle" mode="filelist">
+    <h3>Files</h3>
+    <table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+      <tr>
+        <th>Name</th>
+        <th>Errors</th>
+        <th>Warnings</th>
+        <th>Infos</th>
+      </tr>
+      <xsl:for-each select="file[@name and generate-id(.) = generate-id(key('files', @name))]">
+
+        <!-- Sort method 1: Primary by #error, secondary by #warning, tertiary by #info -->
+        <xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error[@severity='error'])"/>
+        <xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error[@severity='warning'])"/>
+        <xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error[@severity='info'])"/>
+        
+        <!-- Sort method 1: Sum(#error+#info+#warning) (uncomment to use, comment method 1)  -->
+        <!--
+        <xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error)"/>
+        -->
+
+        <xsl:variable name="errorCount" select="count(key('files', @name)/error[@severity='error'])"/>
+        <xsl:variable name="warningCount" select="count(key('files', @name)/error[@severity='warning'])"/>
+        <xsl:variable name="infoCount" select="count(key('files', @name)/error[@severity='info'])"/>
+
+        <tr>
+          <xsl:call-template name="alternated-row"/>
+          <td><a href="#f-{translate(@name,'\','/')}"><xsl:value-of select="@name"/></a></td>
+          <td><xsl:value-of select="$errorCount"/></td>
+          <td><xsl:value-of select="$warningCount"/></td>
+          <td><xsl:value-of select="$infoCount"/></td>
+        </tr>
+      </xsl:for-each>
+    </table>
+  </xsl:template>
+
+
+  <xsl:template match="file">
+    <a name="f-{translate(@name,'\','/')}"></a>
+    <h3>File <xsl:value-of select="@name"/></h3>
+
+    <table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+      <tr>
+        <th>Severity</th>
+        <th>Error Description</th>
+        <th>Line</th>
+      </tr>
+        <xsl:for-each select="key('files', @name)/error">
+          <xsl:sort data-type="number" order="ascending" select="@line"/>
+      <tr>
+        <xsl:call-template name="alternated-row"/>
+        <td><xsl:value-of select="@severity"/></td>
+        <td><xsl:value-of select="@message"/></td>
+        <td><xsl:value-of select="@line"/></td>
+      </tr>
+      </xsl:for-each>
+    </table>
+    <a href="#top">Back to top</a>
+  </xsl:template>
+
+
+  <xsl:template match="checkstyle" mode="summary">
+    <h3>Summary</h3>
+        <xsl:variable name="fileCount" select="count(file[@name and generate-id(.) = generate-id(key('files', @name))])"/>
+    <xsl:variable name="errorCount" select="count(file/error[@severity='error'])"/>
+    <xsl:variable name="warningCount" select="count(file/error[@severity='warning'])"/>
+    <xsl:variable name="infoCount" select="count(file/error[@severity='info'])"/>
+    <table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
+    <tr>
+      <th>Files</th>
+      <th>Errors</th>
+      <th>Warnings</th>
+      <th>Infos</th>
+    </tr>
+    <tr>
+      <xsl:call-template name="alternated-row"/>
+      <td><xsl:value-of select="$fileCount"/></td>
+      <td><xsl:value-of select="$errorCount"/></td>
+      <td><xsl:value-of select="$warningCount"/></td>
+      <td><xsl:value-of select="$infoCount"/></td>
+    </tr>
+    </table>
+  </xsl:template>
+
+  <xsl:template name="alternated-row">
+    <xsl:attribute name="class">
+      <xsl:if test="position() mod 2 = 1">a</xsl:if>
+      <xsl:if test="position() mod 2 = 0">b</xsl:if>
+    </xsl:attribute>
+  </xsl:template>
+</xsl:stylesheet>
+
+


### PR DESCRIPTION
Validates the source code style for all compiled java sources against the [SUN JAVA code style conventions](https://www.oracle.com/java/technologies/javase/codeconventions-contents.html).

This PR will conflict with #247 so there is ample time to get this tweaked to perfection. I will solve merge conflicts of course and apply any other changes required.

Adds a new ant target `checkstyle` which is not wired in at the moment and needs to be run manually, but it is dependent on compile as it will only consider source code that are compiled. It is currently configured not to fail and also does no print any exceptions to stdout but instead generate config files to `build` and an html report to `report` folder.

The current configuration reports 286761 from 1394 source files and generates this [checkstyle_report.zip](https://github.com/javacc21/javacc21/files/10328406/checkstyle_report.zip) report.

The [checkstyle plugin](https://checkstyle.sourceforge.io/) really does not impose any conventions on us, there are two different [style configurations](https://checkstyle.sourceforge.io/style_configs.html) to start from based on either the standard Google or Sun java style conventions. These can be modified of course but the plugin is also [very configurable](https://checkstyle.sourceforge.io/config.html) allowing us to change constants, toggle group settings and even allows fine grained choice on every last setting. Once we find the style we are comfortable with it will ensure that things stay uniform prompting us and failing the build when any deviations occur.

By doing this little work up front it becomes another thing we never have to worry about again.