### PR TITLE
Fix ant test target failing

### DIFF
--- a/examples/csharp/build.xml
+++ b/examples/csharp/build.xml
@@ -41,7 +41,7 @@
 </target>
 
 <target name="test" depends="compile">
-     <java fork="true" failonerror="true" classname="CSParse">
+     <java fork="true" classpath="." failonerror="true" classname="CSParse">
          <assertions><enable/></assertions>
          <arg value="testfiles"/>
      </java>

--- a/examples/freemarker/build.xml
+++ b/examples/freemarker/build.xml
@@ -28,18 +28,18 @@
 
 <target name="test" depends="build">
      <echo>Here is a really simple FEL example: 2+2</echo>
-     <java fork="true" failonerror="true" classname="fel.FELParser" inputstring="2+2">
+     <java fork="true" classpath="." failonerror="true" classname="fel.FELParser" inputstring="2+2">
         <assertions><enable/></assertions>
      </java>
      <echo>Okay, a bit more complex example now: x.y.z(foo, &quot;bar&quot;)?upper_case</echo>
-     <java fork="true" failonerror="true" classname="fel.FELParser" inputstring='x.y.z(foo, "bar")?upper_case'>
+     <java fork="true" classpath="." failonerror="true" classname="fel.FELParser" inputstring='x.y.z(foo, "bar")?upper_case'>
         <assertions><enable/></assertions>
      </java>
 	 <echo>Now let's try out the full FTL parser on the templates used in JavaCC</echo>
-     <java fork="true" failonerror="true" classname="ftl.FTLParser">
+     <java fork="true" classpath="." failonerror="true" classname="ftl.FTLParser">
        <assertions><enable/></assertions>
      	 <arg value = "../../src/ftl/java"/>
-	 </java>
+     </java>
 </target>
 
 </project>

--- a/examples/java/build.xml
+++ b/examples/java/build.xml
@@ -27,7 +27,7 @@
 </target>
 
 <target name="test" depends="compile">
-     <java fork="true" failonerror="true" classname="JParse">
+     <java fork="true" classpath="." failonerror="true" classname="JParse">
          <assertions><enable/></assertions>
          <arg value="org/parsers/java"/>
      </java>
@@ -36,7 +36,7 @@
         Okay, that seems okay. Now let's dump the parse tree for a single source file
         -------------------
      </echo>
-     <java fork="true" failonerror="true" classname="JParse">
+     <java fork="true" classpath="." failonerror="true" classname="JParse">
 	       <assertions><enable/></assertions>
          <arg value="org/parsers/java/ast/CompilationUnit.java"/>
      </java>


### PR DESCRIPTION
Several ant test example targets fail with "Error: Could not find or load main class" or similar. 

Output from running: `ant test`
```
parser-gen:

compile:
[javac] Compiling 168 source files
[javac] warning: [options] bootstrap class path not set in conjunction with -source 8
[javac] 1 warning

test:
[java] Error: Could not find or load main class JParse
[java] Caused by: java.lang.ClassNotFoundException: JParse

BUILD FAILED
/home/intriazen/git/javacc21/build.xml:153: The following error occurred while executing this line:
/home/intriazen/git/javacc21/examples/java/build.xml:30: Java returned: 1

Total time: 23 seconds
```
Adding a `classpath` attribute to the java task fixes the problem.